### PR TITLE
fix: ReadFieldError not used if struct has no fields

### DIFF
--- a/protoc-gen-fastpb/generator/generator.go
+++ b/protoc-gen-fastpb/generator/generator.go
@@ -198,8 +198,10 @@ func (f *fgMessage) GenFastRead(g *protogen.GeneratedFile) {
 	g.P(`return offset, nil`)
 	g.P(`SkipFieldError:`)
 	g.P(`return offset, fmt.Errorf("%T cannot parse invalid wire-format data, error: %s", x, err)`)
-	g.P(`ReadFieldError:`)
-	g.P(`return offset, fmt.Errorf("%T read field %d '%s' error: %s", x, number, fieldIDToName_` + f.name() + `[number], err)`)
+	if len(f.m.Fields) > 0 {
+		g.P(`ReadFieldError:`)
+		g.P(`return offset, fmt.Errorf("%T read field %d '%s' error: %s", x, number, fieldIDToName_` + f.name() + `[number], err)`)
+	}
 	g.P(`}`)
 	g.P()
 }


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->
fix
#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: fix: ReadFieldError not used if struct has no fields
zh: 修复定义空 struct 会导致生成多余的 ReadFieldError 的问题

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
none