### PR TITLE
refactor: only init span cache when enable

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,10 +1,12 @@
 name: Pull Request Check
+permissions:
+  contents: read
 
-on: [pull_request]
+on: [ pull_request ]
 
 jobs:
   compliant:
-    runs-on: [self-hosted, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -13,31 +15,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  staticcheck:
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: 1.18
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: reviewdog-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            reviewdog-${{ runner.os }}-go-
-
-      - uses: reviewdog/action-staticcheck@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].
-          reporter: github-pr-review
-          # Report all results.
-          filter_mode: nofilter
-          # Exit with 1 when it find at least one finding.
-          fail_on_error: true
-          # Set staticcheck flags
-          staticcheck_flags: -checks=inherit,-SA1029
+      - name: Check Spell
+        uses: crate-ci/typos@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,50 +1,42 @@
 name: Tests
+permissions:
+  contents: read
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
-  lint-and-ut:
-    runs-on: self-hosted
+  unittest:
+    strategy:
+      matrix:
+        go: [ "1.18", oldstable, stable ]
+        os: [ ubuntu-24.04-arm, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      - name: Lint
-        run: |
-          go vet -stdmethods=false $(go list ./...)
-          go install mvdan.cc/gofumpt@v0.2.0
-          test -z "$(gofumpt -l -extra .)"
+          go-version: ${{ matrix.go }}
+          cache: true # false for self-hosted runners
 
       - name: Unit Test
-        run: go test -race -covermode=atomic -coverprofile=coverage.out ./...
+        run: go test ./...
 
   benchmark:
-    runs-on: self-hosted
+    strategy:
+      matrix:
+        go: [ "1.18", oldstable, stable ]
+        os: [ ubuntu-24.04-arm, ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
-
-      - uses: actions/cache@v3
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          go-version: ${{ matrix.go }}
+          cache: true # false for self-hosted runners
 
       - name: Benchmark
-        run: go test -bench=. -benchmem -run=none ./...
+        run: go test -bench=. -benchmem -run=none ./... -benchtime=100ms

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,4 @@
+[files]
+extend-exclude = [
+    "benchmark/gogo_gen/",
+]

--- a/fastpb_impl.go
+++ b/fastpb_impl.go
@@ -33,15 +33,22 @@ var Impl impl
 // to make room).
 const speculativeLength = 1
 
+type spanCacheImpl interface {
+	Copy(buf []byte) []byte
+}
+
 var (
 	_               Protocol = impl{}
-	spanCache                = span.NewSpanCache(1024 * 1024) // 1MB
-	spanCacheEnable bool     = false
+	spanCache       spanCacheImpl
+	spanCacheEnable = false
 )
 
 // SetSpanCache enable/disable binary protocol bytes/string allocator
 func SetSpanCache(enable bool) {
 	spanCacheEnable = enable
+	if enable && spanCache == nil {
+		spanCache = span.NewSpanCache(1024 * 1024) // 1MB
+	}
 }
 
 type impl struct{}


### PR DESCRIPTION
#### What type of PR is this?
refactor

<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: 
zh:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
